### PR TITLE
Fix chars_from_hex to handle odd numbers of digits correctly

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -32,6 +32,9 @@ function chars_from_hex(inputstr) {
   var outputstr = '';
   inputstr = inputstr.replace(/[^A-Fa-f0-9]/g, '');
   inputstr = inputstr.split('');
+  if(inputstr.length % 2 != 0) {
+    inputstr.unshift('0');
+  }
   for(var i=0; i<inputstr.length; i+=2) {
     outputstr += String.fromCharCode(parseInt(inputstr[i]+''+inputstr[i+1], 16));
   }


### PR DESCRIPTION
Authentication can fail because `chars_from_hex` (called by `_generateDiffieHellmanParameters` via `_toBase64`) returns incorrect conversions for bigints that are expressed in an odd number of hex digits.

Before the change, the following statements were true:

```
parseInt(hex_from_chars(chars_from_hex("abc")), 16) !== parseInt("abc", 16)
hex_from_chars(chars_from_hex("abc")) !== "0abc"
hex_from_chars(chars_from_hex("abc")) === "ab0c"
```
