### PR TITLE
Async association storage, don't mess with require paths

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -26,7 +26,7 @@
  * vim: set sw=2 ts=2 et tw=80 : 
  */
 
-var base64 = require('base64').base64;
+var base64 = require('./base64').base64;
 
 function chars_from_hex(inputstr) {
   var outputstr = '';

--- a/openid.js
+++ b/openid.js
@@ -26,17 +26,14 @@
  * vim: set sw=2 ts=2 et tw=80 : 
  */
 
-require.paths.unshift(__dirname + '/lib');
-require.paths.unshift(__dirname);
-
-var bigint = require('bigint'),
-    convert = require('convert'),
+var bigint = require('./lib/bigint'),
+    convert = require('./lib/convert'),
     crypto = require('crypto'),
     http = require('http'),
     https = require('https'),
     querystring = require('querystring'),
     url = require('url'),
-    xrds = require('xrds');
+    xrds = require('./lib/xrds');
 
 var _associations = {};
 var _discoveries = {};

--- a/sample.js
+++ b/sample.js
@@ -23,9 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  */
 
-require.paths.unshift(__dirname);
-
-var openid = require('openid');
+var openid = require('./openid');
 var url = require('url');
 var querystring = require('querystring');
 

--- a/test/openid_fast_tests.js
+++ b/test/openid_fast_tests.js
@@ -22,10 +22,8 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  */
-require.paths.unshift(__dirname + '/../');
-
 var assert = require('assert');
-var openid = require('openid');
+var openid = require('../openid');
 
 exports.testVerificationUrl = function(test)
 {

--- a/test/openid_integration_tests.js
+++ b/test/openid_integration_tests.js
@@ -22,10 +22,9 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  */
-require.paths.unshift(__dirname + '/../');
 
 var assert = require('assert');
-var openid = require('openid');
+var openid = require('../openid');
 
 exports.testResolveFailed = function(test)
 {

--- a/test/xrds_tests.js
+++ b/test/xrds_tests.js
@@ -23,10 +23,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  */
 
-require.paths.unshift(__dirname + '/../lib/');
-
 var assert = require('assert');
-var xrds = require('xrds');
+var xrds = require('../lib/xrds');
 
 exports.testXrdsSampleParse = function(test)
 {


### PR DESCRIPTION
Saving and loading associations should be async for storage in a database or key/value store. Also removed manipulation of require paths by requiring correctly.

Association store changes are non-backwards compatible.
