### PR TITLE
Support for multiple response values in AX

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -22,8 +22,8 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  *
- * -*- Mode: JS; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- 
- * vim: set sw=2 ts=2 et tw=80 : 
+ * -*- Mode: JS; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: set sw=2 ts=2 et tw=80 :
  */
 
 var bigint = require('./lib/bigint'),
@@ -50,8 +50,8 @@ openid.RelyingParty = function(returnUrl, realm, stateless, strict, extensions)
 }
 
 openid.RelyingParty.prototype.authenticate = function(identifier, immediate, callback)
-{ 
-  openid.authenticate(identifier, this.returnUrl, this.realm, 
+{
+  openid.authenticate(identifier, this.returnUrl, this.realm,
       immediate, this.stateless, callback, this.extensions, this.strict);
 }
 
@@ -175,7 +175,7 @@ var _get = function(getUrl, params, callback, redirects)
   {
     path += '?' + getUrl.query;
   }
-  var options = 
+  var options =
   {
     host: getUrl.hostname,
     port: _isDef(getUrl.port) ? parseInt(getUrl.port, 10) :
@@ -210,7 +210,7 @@ var _get = function(getUrl, params, callback, redirects)
 
     res.on('end', function() { done(); });
     res.on('close', function() { done(); });
-  }).on('error', function(error) 
+  }).on('error', function(error)
   {
     return callback(error);
   });
@@ -228,13 +228,13 @@ var _post = function(postUrl, data, callback, redirects)
   }
 
   var encodedData = _encodePostData(data);
-  var options = 
+  var options =
   {
     host: postUrl.hostname,
     path: path,
     port: _isDef(postUrl.port) ? postUrl.port :
       (postUrl.protocol == 'https:' ? 443 : 80),
-    headers: 
+    headers:
     {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Content-Length': encodedData.length
@@ -344,7 +344,7 @@ var _parseXrds = function(xrdsUrl, xrdsData)
     {
       provider.version = 'http://specs.openid.net/auth/2.0';
     }
-    else if(service.type == 'http://openid.net/signon/1.0' || 
+    else if(service.type == 'http://openid.net/signon/1.0' ||
       service.type == 'http://openid.net/signon/1.1')
     {
       provider.version = service.type;
@@ -414,22 +414,22 @@ var _parseHtml = function(htmlUrl, html, callback, hops)
     else
     {
       var localId = _matchLinkTag(html, 'openid.delegate');
-      callback([{ 
+      callback([{
         version: 'http://openid.net/signon/1.1',
-        endpoint: provider, 
+        endpoint: provider,
         claimedIdentifier: htmlUrl,
-        localIdentifier : localId 
+        localIdentifier : localId
       }]);
     }
   }
   else
   {
     var localId = _matchLinkTag(html, 'openid2.local_id');
-    callback([{ 
-      version: 'http://specs.openid.net/auth/2.0/signon', 
-      endpoint: provider, 
+    callback([{
+      version: 'http://specs.openid.net/auth/2.0/signon',
+      endpoint: provider,
       claimedIdentifier: htmlUrl,
-      localIdentifier : localId 
+      localIdentifier : localId
     }]);
   }
 }
@@ -519,7 +519,7 @@ var _resolveHtml = function(identifier, callback, hops, data)
 openid.discover = function(identifier, callback)
 {
   identifier = _normalizeIdentifier(identifier);
-  if(!identifier) 
+  if(!identifier)
   {
     return callback({ message: 'Invalid identifier' }, null);
   }
@@ -570,15 +570,15 @@ var _generateDiffieHellmanParameters = function(algorithm)
   {
     a = new bigint.BigInteger(160, 1, new bigint.SecureRandom());
   }
-  else 
+  else
   {
     a = new bigint.BigInteger(256, 1, new bigint.SecureRandom());
   }
   var j = g.modPow(a, p);
 
   return { p: _toBase64(p),
-    g: _toBase64(g), 
-    a: _toBase64(a), 
+    g: _toBase64(g),
+    a: _toBase64(a),
     j: _toBase64(j) };
 }
 
@@ -603,15 +603,15 @@ openid.associate = function(provider, callback, strict, algorithm)
   {
     if ((statusCode != 200 && statusCode != 400) || data === null)
     {
-      return callback({ 
-        message: 'HTTP request failed' 
-      }, { 
-        error: 'HTTP request failed', 
-        error_code: ''  + statusCode, 
-        ns: 'http://specs.openid.net/auth/2.0' 
+      return callback({
+        message: 'HTTP request failed'
+      }, {
+        error: 'HTTP request failed',
+        error_code: ''  + statusCode,
+        ns: 'http://specs.openid.net/auth/2.0'
       });
     }
-    
+
     data = _decodePostData(data);
 
     if(data.error_code == 'unsupported-type' || !_isDef(data.ns))
@@ -639,7 +639,7 @@ openid.associate = function(provider, callback, strict, algorithm)
           // HMAC-SHA1 has already been attempted with a blank session
           // type as per the OpenID 1.0/1.1 specification.
           // (See http://openid.net/specs/openid-authentication-1_1.html#mode_associate)
-          // However, providers like wordpress.com don't follow the 
+          // However, providers like wordpress.com don't follow the
           // standard and reject these requests, but accept OpenID 2.0
           // style requests without a session type, so we have to give
           // those a shot as well.
@@ -768,8 +768,8 @@ openid.authenticate = function(identifier, returnUrl, realm, immediate, stateles
           {
             return callback({ message: 'Cannot retain discovered information; the provider does not contain the required attributes' });
           }
-          
-          return openid.saveDiscoveredInformation(useLocalIdentifierAsKey ? provider.localIdentifier : provider.claimedIdentifier, 
+
+          return openid.saveDiscoveredInformation(useLocalIdentifierAsKey ? provider.localIdentifier : provider.claimedIdentifier,
             provider, function(error)
           {
             if(error)
@@ -795,7 +795,7 @@ openid.authenticate = function(identifier, returnUrl, realm, immediate, stateles
       var currentProvider = providers[providerIndex];
       if(stateless)
       {
-        _requestAuthentication(currentProvider, null, returnUrl, 
+        _requestAuthentication(currentProvider, null, returnUrl,
           realm, immediate, extensions || {}, successOrNext);
       }
 
@@ -809,11 +809,11 @@ openid.authenticate = function(identifier, returnUrl, realm, immediate, stateles
           }
           else
           {
-            _requestAuthentication(currentProvider, answer.assoc_handle, returnUrl, 
+            _requestAuthentication(currentProvider, answer.assoc_handle, returnUrl,
               realm, immediate, extensions || {}, successOrNext);
           }
         });
-        
+
       }
     };
 
@@ -902,11 +902,11 @@ openid.verifyAssertion = function(requestOrUrl, callback, stateless, extensions)
       if(requestOrUrl.headers['content-type'] == 'application/x-www-form-urlencoded') {
         // POST response received
         var data = '';
-        
+
         requestOrUrl.on('data', function(chunk) {
           data += chunk;
         });
-        
+
         requestOrUrl.on('end', function() {
           var params = querystring.parse(data);
           return _verifyAssertionData(params, callback, stateless, extensions);
@@ -915,7 +915,7 @@ openid.verifyAssertion = function(requestOrUrl, callback, stateless, extensions)
       else {
         return callback({ message: 'Invalid POST response from OpenID provider' });
       }
-      
+
       return; // Avoid falling through to GET method assertion
     }
     else if(requestOrUrl.method != 'GET') {
@@ -942,7 +942,7 @@ var _verifyAssertionData = function(params, callback, stateless, extensions) {
   }
 
   // TODO: Check nonce if OpenID 2.0
-  
+
   _verifyDiscoveredInformation(params, function(error, result)
   {
     return callback(error, result);
@@ -989,12 +989,12 @@ var _verifyDiscoveredInformation = function(params, callback)
       // OpenID 2.0+:
       // If there is no claimed identifier, then the
       // assertion is not about an identity
-      return callback(null, { authenticated: false }); 
+      return callback(null, { authenticated: false });
       }
   }
 
   if (useLocalIdentifierAsKey) {
-    claimedIdentifier = params['openid.identity'];  
+    claimedIdentifier = params['openid.identity'];
   }
   openid.loadDiscoveredInformation(claimedIdentifier, function(error, provider)
   {
@@ -1010,7 +1010,7 @@ var _verifyDiscoveredInformation = function(params, callback)
     else if (useLocalIdentifierAsKey) {
       return callback({ message: 'OpenID 1.0/1.1 response received, but no information has been discovered about the provider. It is likely that this is a fraudulent authentication response.' });
     }
-    
+
     openid.discover(claimedIdentifier, function(error, providers)
     {
       if(error)
@@ -1063,8 +1063,8 @@ var _verifyAssertionAgainstProvider = function(provider, params, callback)
       for(var ext in extensions)
       {
         if (!extensions.hasOwnProperty(ext))
-        { 
-          continue; 
+        {
+          continue;
         }
         var instance = extensions[ext];
         instance.fillResult(params, result);
@@ -1109,7 +1109,7 @@ var _checkSignatureUsingAssociation = function(params, callback)
     {
       return callback({ message:'Association handle does not match provided endpoint' }, {authenticated: false});
     }
-    
+
     var message = '';
     var signedParams = params['openid.signed'].split(',');
     for(var i = 0; i < signedParams.length; i++)
@@ -1140,7 +1140,7 @@ var _checkSignatureUsingAssociation = function(params, callback)
 
 var _checkSignatureUsingProvider = function(params, provider, callback)
 {
-  var requestParams = 
+  var requestParams =
   {
     'openid.mode' : 'check_authentication'
   };
@@ -1176,24 +1176,24 @@ var _checkSignatureUsingProvider = function(params, provider, callback)
 
 /* ==================================================================
  * Extensions
- * ================================================================== 
+ * ==================================================================
  */
 
-var _getExtensionAlias = function(params, ns) 
+var _getExtensionAlias = function(params, ns)
 {
   for (var k in params)
     if (params[k] == ns)
       return k.replace("openid.ns.", "");
 }
 
-/* 
+/*
  * Simple Registration Extension
  * http://openid.net/specs/openid-simple-registration-extension-1_1-01.html
  */
 
 var sreg_keys = ['nickname', 'email', 'fullname', 'dob', 'gender', 'postcode', 'country', 'language', 'timezone'];
 
-openid.SimpleRegistration = function SimpleRegistration(options) 
+openid.SimpleRegistration = function SimpleRegistration(options)
 {
   this.requestParams = {'openid.ns.sreg': 'http://openid.net/extensions/sreg/1.1'};
   if (options.policy_url)
@@ -1203,7 +1203,7 @@ openid.SimpleRegistration = function SimpleRegistration(options)
   for (var i = 0; i < sreg_keys.length; i++)
   {
     var key = sreg_keys[i];
-    if (options[key]) 
+    if (options[key])
     {
       if (options[key] == 'required')
       {
@@ -1238,11 +1238,11 @@ openid.SimpleRegistration.prototype.fillResult = function(params, result)
   }
 };
 
-/* 
+/*
  * User Interface Extension
- * http://svn.openid.net/repos/specifications/user_interface/1.0/trunk/openid-user-interface-extension-1_0.html 
+ * http://svn.openid.net/repos/specifications/user_interface/1.0/trunk/openid-user-interface-extension-1_0.html
  */
-openid.UserInterface = function UserInterface(options) 
+openid.UserInterface = function UserInterface(options)
 {
   if (typeof(options) != 'object')
   {
@@ -1250,7 +1250,7 @@ openid.UserInterface = function UserInterface(options)
   }
 
   this.requestParams = {'openid.ns.ui': 'http://specs.openid.net/extensions/ui/1.0'};
-  for (var k in options) 
+  for (var k in options)
   {
     this.requestParams['openid.ui.' + k] = options[k];
   }
@@ -1261,16 +1261,16 @@ openid.UserInterface.prototype.fillResult = function(params, result)
   // TODO: Fill results
 }
 
-/* 
+/*
  * Attribute Exchange Extension
- * http://openid.net/specs/openid-attribute-exchange-1_0.html 
+ * http://openid.net/specs/openid-attribute-exchange-1_0.html
  * Also see:
- *  - http://www.axschema.org/types/ 
+ *  - http://www.axschema.org/types/
  *  - http://code.google.com/intl/en-US/apis/accounts/docs/OpenID.html#Parameters
  */
 // TODO: count handling
 
-var attributeMapping = 
+var attributeMapping =
 {
     'http://axschema.org/contact/country/home': 'country'
   , 'http://axschema.org/contact/email': 'email'
@@ -1282,8 +1282,8 @@ var attributeMapping =
   , 'http://axschema.org/namePerson': 'fullname'
 };
 
-openid.AttributeExchange = function AttributeExchange(options) 
-{ 
+openid.AttributeExchange = function AttributeExchange(options)
+{
   this.requestParams = {'openid.ns.ax': 'http://openid.net/srv/ax/1.0',
     'openid.ax.mode' : 'fetch_request'};
   var required = [];
@@ -1301,7 +1301,7 @@ openid.AttributeExchange = function AttributeExchange(options)
     }
   }
   var self = this;
-  required = required.map(function(ns, i) 
+  required = required.map(function(ns, i)
   {
     var attr = attributeMapping[ns] || 'req' + i;
     self.requestParams['openid.ax.type.' + attr] = ns;
@@ -1326,9 +1326,10 @@ openid.AttributeExchange = function AttributeExchange(options)
 openid.AttributeExchange.prototype.fillResult = function(params, result)
 {
   var extension = _getExtensionAlias(params, 'http://openid.net/srv/ax/1.0') || 'ax';
-  var regex = new RegExp('^openid\\.' + extension + '\\.(value|type)\\.(\\w+)$');
+  var regex = new RegExp('^openid\\.' + extension + '\\.(value|type|count)\\.([\\w\\.]+)$');
   var aliases = {};
   var values = {};
+  var counts = {};
   for (var k in params)
   {
     if (!params.hasOwnProperty(k)) { continue; }
@@ -1341,16 +1342,40 @@ openid.AttributeExchange.prototype.fillResult = function(params, result)
     {
       aliases[params[k]] = matches[2];
     }
+    else if (matches[1] == 'count')
+    {
+      counts[matches[2]] = params[k];
+    }
     else
     {
       values[matches[2]] = params[k];
     }
   }
-  for (var ns in aliases) 
+  for (var ns in aliases)
   {
-    if (aliases[ns] in values)
+    var alias = aliases[ns];
+    if (alias in counts)
     {
-      result[aliases[ns]] = values[aliases[ns]];
+      var arr = [];
+      var count = counts[alias];
+
+      for (x = 1;x <= count; x++)
+      {
+        var offset = alias + '.' + x;
+        if (offset in values)
+        {
+          arr.push(values[offset]);
+        }
+      }
+
+      result[alias] = arr.length == 1 ? arr[0] : arr;
+    }
+    else
+    {
+      if (alias in values)
+      {
+        result[alias] = values[alias];
+      }
     }
   }
 }
@@ -1367,8 +1392,8 @@ openid.OAuthHybrid.prototype.fillResult = function(params, result)
 {
   var extension = _getExtensionAlias(params, 'http://specs.openid.net/extensions/oauth/1.0') || 'oauth'
     , token_attr = 'openid.' + extension + '.request_token';
-  
-  
+
+
   if(params[token_attr] !== undefined)
   {
     result['request_token'] = params[token_attr];


### PR DESCRIPTION
This will support multiple response values coming back in AX response, e.g. 

openid.ns.ax=http://openid.net/srv/ax/1.0
openid.ax.mode=fetch_response
openid.ax.type.fname=http://example.com/schema/fullname
openid.ax.type.gender=http://example.com/schema/gender
openid.ax.type.fav_dog=http://example.com/schema/favourite_dog
openid.ax.type.fav_movie=http://example.com/schema/favourite_movie
openid.ax.value.fname=John Smith
openid.ax.count.gender=0
openid.ax.value.fav_dog=Spot
openid.ax.count.fav_movie=2
openid.ax.value.fav_movie.1=Movie1
openid.ax.value.fav_movie.2=Movie2
openid.ax.update_url=http://idconsumer.com/update?transaction_id=a6b5c41

This currently just breaks with no values being found for fav_movie since the names don't match exactly.
