### PR TITLE
Extra : in url breaks OpenId in Linux.

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -534,7 +534,7 @@ var _resolveHostMeta = function(identifier, strict, callback, fallBackToProxy)
   }
   else
   {
-    hostMetaUrl = host.protocol + '://' + host.host + '/.well-known/host-meta';
+    hostMetaUrl = host.protocol + '//' + host.host + '/.well-known/host-meta';
   }
   if(!hostMetaUrl)
   {


### PR DESCRIPTION
Removed extra `:` causing urls to be invalid and break in Linux while still working in OSX. `http:://opower.com/.well-known/host-meta` instead of `http://opower.com/.well-known/host-meta`
