### PR TITLE
fixes havard/node-openid/#78 by adding support for PAPE

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -1453,3 +1453,21 @@ openid.OAuthHybrid.prototype.fillResult = function(params, result)
     result['request_token'] = params[token_attr];
   }
 };
+
+/* 
+ * PAPE Extension
+ * http://specs.openid.net/extensions/pape/1.0
+ */
+openid.PAPE = function PAPE(options) 
+{
+  this.requestParams = {'openid.ns.pape': 'http://specs.openid.net/extensions/pape/1.0'};
+  for (var k in options) 
+  {
+    this.requestParams['openid.pape.' + k] = options[k];
+  }
+};
+
+openid.PAPE.prototype.fillResult = function(params, result)
+{
+	// So far not needed
+}

--- a/sample.js
+++ b/sample.js
@@ -45,6 +45,10 @@ var extensions = [new openid.UserInterface(),
                         "http://axschema.org/contact/email": "required",
                         "http://axschema.org/namePerson/friendly": "required",
                         "http://axschema.org/namePerson": "required"
+                      }),
+                  new openid.PAPE(
+                      {
+                        "max_auth_age": 0
                       })];
 
 var relyingParty = new openid.RelyingParty(


### PR DESCRIPTION
Adds PAPE class to support PAPE Extensions. Results are not
looked at because it was developed against Google. Google does not
have PAPE params that return results.

Updated sample.js to include how to use the PAPE Extension.

Sorry about the several pushes. I'm new to github and didn't understand the workflow right off the bat.
