### PR TITLE
match endpoint on either the whole string or the part before the ?.

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -1094,13 +1094,25 @@ var _verifyAssertionAgainstProvider = function(provider, params, stateless, exte
   if(provider.version.indexOf('2.0') !== -1)
   {
     var endpoint = params['openid.op_endpoint'];
-    if (endpoint) {
+
+    
+
+    var endPointMatch = false;
+    
+    if(endpoint && !endPointMatch){
+      endPointMatch = provider.endpoint == endpoint
+    }
+    
+    if(endpoint && !endPointMatch){
       var qsIndex = endpoint.indexOf('?');
       if (qsIndex !== -1) {
-        endpoint = endpoint.substring(0, qsIndex);
+        endPointMatch = provider.endpoint == endpoint.substring(0, qsIndex);
       }
     }
-    if (provider.endpoint != endpoint) 
+    
+
+
+    if (!endPointMatch) 
     {
       return callback({ message: 'OpenID provider endpoint in assertion response does not match discovered OpenID provider endpoint' });
     }


### PR DESCRIPTION
I use this fix to make the library work with google apps.

I just noticed that there is already another fix for this issue available via a pull request! It would be great if you could merge either this one or the other one and publish it to npm!

happy holidays!
