### PR TITLE
Support for OpenId Provider Authentication Policy Extension 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This library comes with built-in support for the following OpenID extensions:
  - The Attribute Exchange (AX) 1.0 extension is implemented as `openid.AttributeExchange`
  - The OAuth 1.0 extension is implemented as `openid.OAuthHybrid`
  - The User Interface 1.0 extension is implemented as `openid.UserInterface`
+ - The Provider Authentication Policy Extension 1.0 (PAPE) as `openid.pape`
 
 ## Storing association state
 

--- a/openid.js
+++ b/openid.js
@@ -1503,3 +1503,87 @@ openid.OAuthHybrid.prototype.fillResult = function(params, result)
     result['request_token'] = params[token_attr];
   }
 };
+
+/* 
+ * Provider Authentication Policy Extension (PAPE)
+ * http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html
+ * 
+ * Note that this extension does not validate that the provider is obeying the
+ * authentication request, it only allows the request to be made.
+ *
+ * TODO: verify requested 'max_auth_age' against response 'auth_time'
+ * TODO: verify requested 'auth_level.ns.<cust>' (etc) against response 'auth_level.ns.<cust>'
+ * TODO: verify requested 'preferred_auth_policies' against response 'auth_policies'
+ *
+ */
+
+/* Just the keys that aren't open to customisation */
+var pape_request_keys = ['max_auth_age', 'preferred_auth_policies', 'preferred_auth_level_types' ];
+var pape_response_keys = ['auth_policies', 'auth_time']
+
+/* Some short-hand mappings for auth_policies */ 
+var papePolicyNameMap = 
+{
+    'phishing-resistant': 'http://schemas.openid.net/pape/policies/2007/06/phishing-resistant',
+    'multi-factor': 'http://schemas.openid.net/pape/policies/2007/06/multi-factor',
+    'multi-factor-physical': 'http://schemas.openid.net/pape/policies/2007/06/multi-factor-physical',
+    'none' : 'http://schemas.openid.net/pape/policies/2007/06/none'
+}
+ 
+openid.PAPE = function PAPE(options) 
+{
+  this.requestParams = {'openid.ns.pape': 'http://specs.openid.net/extensions/pape/1.0'};
+  for (var k in options) 
+  {
+    if (k === 'preferred_auth_policies') {
+      this.requestParams['openid.pape.' + k] = _getLongPolicyName(options[k]);
+    } else {
+      this.requestParams['openid.pape.' + k] = options[k];
+    }
+  }
+  var util = require('util');
+};
+
+/* you can express multiple pape 'preferred_auth_policies', so replace each
+ * with the full policy URI as per papePolicyNameMapping. 
+ */
+var _getLongPolicyName = function(policyNames) {
+  var policies = policyNames.split(' ');   
+  for (var i=0; i<policies.length; i++) {
+    if (policies[i] in papePolicyNameMap) {
+      policies[i] = papePolicyNameMap[policies[i]];
+    }
+  }
+  return policies.join(' ');
+}
+
+var _getShortPolicyName = function(policyNames) {
+  var policies = policyNames.split(' ');   
+  for (var i=0; i<policies.length; i++) {
+    for (shortName in papePolicyNameMap) {
+      if (papePolicyNameMap[shortName] === policies[i]) {
+        policies[i] = shortName;
+      }
+    }
+  }
+  return policies.join(' ');
+}
+
+openid.PAPE.prototype.fillResult = function(params, result)
+{
+  var extension = _getExtensionAlias(params, 'http://specs.openid.net/extensions/pape/1.0') || 'pape';
+  var paramString = 'openid.' + extension + '.';
+  var thisParam;
+  for (var p in params) {
+    if (params.hasOwnProperty(p)) {
+      if (p.substr(0, paramString.length) === paramString) {
+        thisParam = p.substr(paramString.length);
+        if (thisParam === 'auth_policies') {
+          result[thisParam] = _getShortPolicyName(params[p]);
+        } else {
+          result[thisParam] = params[p];
+        }
+      }
+    }
+  } 
+}

--- a/sample.js
+++ b/sample.js
@@ -45,6 +45,11 @@ var extensions = [new openid.UserInterface(),
                         "http://axschema.org/contact/email": "required",
                         "http://axschema.org/namePerson/friendly": "required",
                         "http://axschema.org/namePerson": "required"
+                      }),
+                  new openid.PAPE(
+                      {
+                        "max_auth_age": 24 * 60 * 60, // one day
+                        "preferred_auth_policies" : "none" //no auth method preferred.
                       })];
 
 var relyingParty = new openid.RelyingParty(

--- a/test/openid_fast_tests.js
+++ b/test/openid_fast_tests.js
@@ -87,3 +87,20 @@ exports.testAttributeExchange = function(test)
   
   test.done();
 }
+
+exports.testPape = function(test)
+{
+  var exampleParams = {
+        "openid.pape.auth_time" : new Date().toISOString(),
+        "openid.pape.auth_policies" : 'http://schemas.openid.net/pape/policies/2007/06/multi-factor http://schemas.openid.net/pape/policies/2007/06/phishing-resistant'
+      };
+  var pape = new openid.PAPE(),
+      results = {};
+  
+  pape.fillResult(exampleParams, results);
+  assert.notEqual(results['auth_time'], undefined);
+  assert.notEqual(results['auth_policies'], undefined);
+  assert.equal(results['auth_policies'], "multi-factor phishing-resistant"); 
+  test.done();
+}
+


### PR DESCRIPTION
Initial support for OpenId PAPE.
- Additional test case in openid_fast_tests.js
- README updated to mention PAPE
- The code itself is at the bottom of openid.js
- sample.js now uses two example attributes.
