### PR TITLE
Fallback to proxy if first attempt fails to find providers, but gets a 200 with data

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -614,7 +614,17 @@ var _resolveHostMeta = function(identifier, strict, callback, fallBackToProxy)
       }
       else
       {
-        _parseHostMeta(data, callback);
+        //Attempt to parse the data but if this fails it may be because
+        //the response to hostMetaUrl was some other http/html resource.
+        //Therefore fallback to the proxy if no providers are found.
+        _parseHostMeta(data, function(providers){
+          if((providers == null || providers.length == 0) && !fallBackToProxy && !strict){
+            _resolveHostMeta(identifier, strict, callback, true);
+          }
+          else{
+            callback(providers);
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
otherwise, if the first domain that is tried is
returning its 404 page with a 200 code, Google
Apps login fails mysteriously

This is essentially the same as #85, except without the querystring trimming that was decided against
