### PR TITLE
Remove unecessary Diffie-Hellman private key generation.

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -686,8 +686,6 @@ var _createDiffieHellmanKeyExchange = function(algorithm)
 
   var dh = crypto.createDiffieHellman(defaultPrime, 'base64');
 
-  var randomPrivateKey = crypto.randomBytes(algorithm == 'DH-SHA1' ? 20 : 32);
-  dh.setPrivateKey(randomPrivateKey, 'binary');
   dh.generateKeys();
 
   return dh;


### PR DESCRIPTION
Diffie-Hellman private key, which is distinct from the **MAC key**, doesn't need to be 160 or 256-bit long, according to [specs](http://openid.net/specs/openid-authentication-2_0.html#dh_sessions). Thus setting the private key manually does not provide extra security than generate it automatically.
