### PR TITLE
keep associate secret unchanged when verifying signature

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -1254,7 +1254,7 @@ var _checkSignatureUsingAssociation = function(params, callback)
       message += param + ':' + value + '\n';
     }
 
-    var hmac = crypto.createHmac(association.type, _fromBase64(association.secret));
+    var hmac = crypto.createHmac(association.type, convert.base64.decode(association.secret));
     hmac.update(message, 'utf8');
     var ourSignature = hmac.digest('base64');
 


### PR DESCRIPTION
If an OpenID provider uses a 32-bit associate secret in btwoc string representation like `<Buffer 00 c3 1e d1 ba 72 60 31 e4 d5 b8 a0 d7 a2 08 e7 77 5d 52 21 cb 43 ed 7a 8a 6d 52 81 b9 ea 0a 9d>`,  the key of created hmac object will be changed by function `convert.unbtwoc()`, which will fail signature verification.
