### PR TITLE
Fix: verifyAssertion times out on POST

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -1022,17 +1022,23 @@ openid.verifyAssertion = function(requestOrUrl, callback, stateless, extensions,
   {
     if(requestOrUrl.method == 'POST') {
       if(requestOrUrl.headers['content-type'] == 'application/x-www-form-urlencoded') {
-        // POST response received
-        var data = '';
-        
-        requestOrUrl.on('data', function(chunk) {
-          data += chunk;
-        });
-        
-        requestOrUrl.on('end', function() {
-          var params = querystring.parse(data);
-          return _verifyAssertionData(params, callback, stateless, extensions, strict);
-        });
+
+        if (requestOrUrl.complete) {
+          return _verifyAssertionData(requestOrUrl.body, callback, stateless, extensions, strict);
+        } else {
+
+          // POST response received
+          var data = '';
+
+          requestOrUrl.on('data', function (chunk) {
+            data += chunk;
+          });
+
+          requestOrUrl.on('end', function () {
+            var params = querystring.parse(data);
+            return _verifyAssertionData(params, callback, stateless, extensions, strict);
+          });
+        }
       }
       else {
         return callback({ message: 'Invalid POST response from OpenID provider' });


### PR DESCRIPTION
I received a POST from the server that was already complete. In that case verify the body as the events will never trigger.

node version: 0.10.33
express version: 3.20.1