### PR TITLE
fixing problem with not being able to authenticate against wordpress or stackexchange

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -1160,7 +1160,7 @@ var _verifyAssertionAgainstProviders = function(providers, params, stateless, ex
   for(var i = 0; i < providers.length; ++i)
   {
     var provider = providers[i];
-    if(!provider.version || provider.version.indexOf(params['openid.ns']) !== 0)
+    if(!!params['openid.ns'] && (!provider.version || provider.version.indexOf(params['openid.ns']) !== 0))
     {
       continue;
     }


### PR DESCRIPTION
If you try to authenticate with wordpress (in the sample app) or stackexchange, authentication fails. I believe this fixes the problem.

Maybe it is related to #119 and or other similar issues.

Please comment and if you agree integrate a.s.a.p.

Thanks,
Andreas