### PR TITLE
Replace custom http logic with request

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "nodeunit": "~0.9.1",
     "sinon": "~1.13.0",
     "nock": "~1.1.0"
+  },
+  "dependencies": {
+    "request": "^2.61.0"
   }
 }


### PR DESCRIPTION
There we go :) No more custom http logic or special fiddling for proxies. Solves the open NO_PROXY issue and all that..

While I tested things by trying it in my own project + the sample.js example, it would be great if somebody could have a second look at this. There is quite a fair chance that this introduces a different behaviour in some setups, so I would recommend bumping the major version for a new release after merging this.