### PR TITLE
Fix xrds/xrds meta parsing

### DIFF
--- a/lib/xrds.js
+++ b/lib/xrds.js
@@ -26,70 +26,46 @@
  * vim: set sw=2 ts=2 et tw=80 : 
  */
 
+var libxmljs = require("libxmljs");
+
 exports.parse  = function(data)
 {
-  data = data.replace(/\r|\n/g, '');
+  function xPathTextOrNull(el, path)
+  {
+    var child = el.get(path);
+    return child ? child.text() : null;
+  }
+
+  var xml = libxmljs.parseXml(data);
   var services = [];
-  var serviceMatches = data.match(/<Service\s*(priority="\d+")?.*?>(.*?)<\/Service>/g);
 
-  if(!serviceMatches)
+  xml.root().find('//*[name()=\'Service\']').forEach(function(service)
   {
-    return services;
-  }
+    var uri = xPathTextOrNull(service, '//*[name()=\'URI\']');
+    if (!uri)
+      return;
 
-  for(var s = 0, len = serviceMatches.length; s < len; ++s)
-  {
-    var service = serviceMatches[s];
-    var svcs = [];
-    var priorityMatch = /<Service.*?priority="(.*?)".*?>/g.exec(service);
-    var priority = 0;
-    if(priorityMatch)
-    {
-      priority = parseInt(priorityMatch[1], 10);
-    }
+    var priorityAttr = service.attr('priority');
+    var priority = priorityAttr ? parseInt(priorityAttr.value()) : 0;
 
-    var typeMatch = null;
-    var typeRegex = new RegExp('<Type(\\s+.*?)?>(.*?)<\\/Type\\s*?>', 'g');
-    while(typeMatch = typeRegex.exec(service))
-    {
-      svcs.push({ priority: priority, type: typeMatch[2] });
-    }
+    var id = (xPathTextOrNull(service, '//*[name()=\'LocalID\']') ||
+              xPathTextOrNull(service, '//*[name()=\'CanonicalID\']'));
 
-    if(svcs.length == 0)
-    {
-      continue;
-    }
+    var delegate = xPathTextOrNull(service, '//*[name()=\'Delegate\']');
 
-    var idMatch = /<(Local|Canonical)ID\s*?>(.*?)<\/\1ID\s*?>/g.exec(service);
-    if(idMatch)
-    {
-      for(var i = 0; i < svcs.length; i++)
-      {
-        var svc = svcs[i];
-        svc.id = idMatch[2];
-      }
-    }
-    
-    var uriMatch = /<URI(\s+.*?)?>(.*?)<\/URI\s*?>/g.exec(service);
-    if(!uriMatch)
-    {
-      continue;
-    }
+    service.find('//*[name()=\'Type\']').forEach(function(type) {
+      var object = {
+        type: type.text(),
+        priority: priority,
+        uri: uri,
+      };
 
-    for(var i = 0; i < svcs.length; i++)
-    {
-      var svc = svcs[i];
-      svc.uri = uriMatch[2];
-    }
+      if (id) object.id = id;
+      if (delegate) object.delegate = delegate;
 
-    var delegateMatch = /<(.*?Delegate)\s*?>(.*)<\/\1\s*?>/g.exec(service);
-    if(delegateMatch)
-    {
-      svc.delegate = delegateMatch[2];
-    }
-
-    services.push.apply(services, svcs);
-  }
+      services.push(object);
+    });
+  });
 
   services.sort(function(a, b) 
   { 
@@ -100,3 +76,4 @@ exports.parse  = function(data)
 
   return services;
 }
+

--- a/openid.js
+++ b/openid.js
@@ -282,13 +282,17 @@ var _parseXrds = function(xrdsUrl, xrdsData)
 
 var _matchMetaTag = function(html)
 {
-  var metaTagMatches = /<meta\s+.*?http-equiv="x-xrds-location"\s+(.*?)>/ig.exec(html);
-  if(!metaTagMatches || metaTagMatches.length < 2)
+  var metaTagMatches = /<meta\s+(?:.*?)http-equiv="x-xrds-location"\s+(.*?)>/ig.exec(html);
+  // try the other way around, first content, then http-equiv
+  if (!metaTagMatches)
+    metaTagMatches = /<meta\s+?content="[^""]+"\s+?http-equiv="x-xrds-location".*?>/ig.exec(html);
+
+  if(!metaTagMatches)
   {
     return null;
   }
 
-  var contentMatches = /content="(.*?)"/ig.exec(metaTagMatches[1]);
+  var contentMatches = /content="(.*?)"/ig.exec(metaTagMatches[0]);
   if(!contentMatches || contentMatches.length < 2)
   {
     return null;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nock": "~1.1.0"
   },
   "dependencies": {
+    "libxmljs": "^0.15.0",
     "request": "^2.61.0"
   }
 }


### PR DESCRIPTION
The current code fails quite miserably for any "non-standard" writing of XML/HTML tags. More particularly, it can't handle the content attribute appearing before the http-equiv attribute for meta tags and comments in xrds files.

I replaced the regexes for the xrds parsing with a libxml2 implementation, but left the regex for the meta tag parsing, only added a second one to test for the reverse order. We may want to consider moving to a more robust solution in that place as well.