### PR TITLE
Fix _parseHostMeta

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -359,7 +359,7 @@ var _parseHostMeta = function(hostMeta, callback)
   var match = /^Link: <([^\n\r]+)>;/.exec(hostMeta);
   if(match != null)
   {
-    var xriUrl = match[0].slice(7,match.length - 4);
+    var xriUrl = match[0].slice(7, -4);
     _resolveXri(xriUrl, callback);
   }
   else


### PR DESCRIPTION
`xriUrl` is `slice`d with its own length, instead of the matches array's.