### PR TITLE
Fix verifyAssertion to support HapiJS request.method

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -879,7 +879,7 @@ openid.verifyAssertion = function(requestOrUrl, originalReturnUrl, callback, sta
   var assertionUrl = requestOrUrl;
   if(typeof(requestOrUrl) !== typeof(''))
   {
-    if(requestOrUrl.method == 'POST') {
+    if(requestOrUrl.method.toUpperCase() == 'POST') {
       if((requestOrUrl.headers['content-type'] || '').toLowerCase().indexOf('application/x-www-form-urlencoded') === 0) {
         // POST response received
         var data = '';
@@ -899,7 +899,7 @@ openid.verifyAssertion = function(requestOrUrl, originalReturnUrl, callback, sta
       
       return; // Avoid falling through to GET method assertion
     }
-    else if(requestOrUrl.method != 'GET') {
+    else if(requestOrUrl.method.toUpperCase() != 'GET') {
       return callback({ message: 'Invalid request method from OpenID provider' });
     }
     assertionUrl = requestOrUrl.url;


### PR DESCRIPTION
Fix verifyAssertion to support HapiJS request.method [Link to HapiJS route docs](http://hapijs.com/api/0.13.1#route-handler).  HapiJS returns the method as a lowercase string, by adding the toUpperCase() this fixes the issue and OpenID works correctly.  This should also continue to work with other frameworks like express.