### PR TITLE
Fix a possible typo in `verifyReturnUrl` routine

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -935,7 +935,7 @@ var _verifyReturnUrl = function (assertionUrl, originalReturnUrl) {
 
   if (originalReturnUrl.protocol !== receivedReturnUrl.protocol || // Verify scheme against original return URL
       originalReturnUrl.host !== receivedReturnUrl.host || // Verify authority against original return URL
-      assertionUrl.pathname !== receivedReturnUrl.pathname) { // Verify path against current request URL
+      originalReturnUrl.pathname !== receivedReturnUrl.pathname) { // Verify path against current request URL
     return false;
   }
 


### PR DESCRIPTION
This check happens to be always invalid for me. The route for `returnURL` is registered in a nested router (using `app.use` from the main express app), and thus the `assertionUrl.pathname` option is not equal to `receivedReturnUrl.pathname`. I guess it is just a typo and should be fixed to the check against `originalReturnUrl` as in other places in the same `if`.