### PR TITLE
Fixes ReferenceError: crypto is not defined, Initiates Variables

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -26,7 +26,7 @@
  * vim: set sw=2 ts=2 et tw=80 : 
  */
 
-var Buffer = require('buffer').Buffer; 
+var Buffer = require('buffer').Buffer,
     crypto = require('crypto'),
     request = require('request'),
     querystring = require('querystring'),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "havard.stranden@gmail.com",
     "web": "http://ox.no"
   },
-  "version": "2.0.5",
+  "version": "2.0.6",
   "repository": {
     "type": "git",
     "url": "http://github.com/havard/node-openid.git"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "havard.stranden@gmail.com",
     "web": "http://ox.no"
   },
-  "version": "2.0.6",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "http://github.com/havard/node-openid.git"


### PR DESCRIPTION
The initial variables `crypto`, `request`, `querystring`, `url`, and `xrds` are never initiated. This can cause a `ReferenceError: crypto is not defined`, as seen:

    ReferenceError: crypto is not defined
    at Object.<anonymous> (C:\Node\xxxxx\node_modules\openid\openid.js:30:12)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (C:\Node\xxxxx\node_modules\passport-openid-node6support\lib\passport-openid\ind
    at Module._compile (module.js:541:32)

I have changed line 29 from `var Buffer = require('buffer').Buffer;` to `var Buffer = require('buffer').Buffer,` - this allows the variables following it to be initiated using `var` from the buffer initialization. 

I have also updated the version to `2.0.6.`