### PR TITLE
openid.mode = cancel should return the correct error

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -971,7 +971,7 @@ openid.verifyAssertion = function(requestOrUrl, originalReturnUrl, callback, sta
 var _verifyReturnUrl = function (assertionUrl, originalReturnUrl) {
   var receivedReturnUrl = assertionUrl.query['openid.return_to'];
   if (!_isDef(receivedReturnUrl)) {
-    return false;
+    return true;
   }
 
   receivedReturnUrl = url.parse(receivedReturnUrl, true);

--- a/test/openid_fast_tests.js
+++ b/test/openid_fast_tests.js
@@ -44,6 +44,7 @@ exports.testVerificationCancel = function(test)
       'http://example.com/verify', 
       function(error, result)
   {
+    test.strictEqual(error.message, 'Authentication cancelled');
     test.ok(!times++);
     test.ok(!result || !result.authenticated);
     test.done();


### PR DESCRIPTION
Cancelling an openid request results in the wrong error message ('Invalid return URL') because url verification fails when `return_to` param is missing.

This PR adds a check in the cancel test for the correct error message and allows urls with no return_to to pass url verification, and fail later, at check for `cancel` mode.
