### PR TITLE
Fix semi-colon to comma

### DIFF
--- a/openid.js
+++ b/openid.js
@@ -28,7 +28,7 @@
 
 var Buffer = require('buffer').Buffer,
     crypto = require('crypto'),
-    http = require('./http');
+    http = require('./http'),
     querystring = require('querystring'),
     url = require('url'),
     xrds = require('./lib/xrds');


### PR DESCRIPTION
When importing this node module in an Electron production build, the semi-colon throws an error "querystring is not defined." Switching to a comma fixes this.